### PR TITLE
prevent hostname validation if the base URL contains mistakes

### DIFF
--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/core/VGSCollect.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/core/VGSCollect.kt
@@ -595,7 +595,7 @@ class VGSCollect {
     private var hasCustomHostname = false
 
     private fun configureHostname(host: String?, tnt: String) {
-        if (!host.isNullOrBlank()) {
+        if (!host.isNullOrBlank() && baseURL.isNotEmpty()) {
             val r = VGSRequest.VGSRequestBuilder()
                 .setMethod(HTTPMethod.GET)
                 .setFormat(VGSHttpBodyFormat.PLAIN_TEXT)


### PR DESCRIPTION
## Feature [ANDROIDSDK-142]

## Description of changes
prevent hostname validation if the base URL contains mistakes

[ANDROIDSDK-142]: https://verygoodsecurity.atlassian.net/browse/ANDROIDSDK-142