### PR TITLE
Added ability to disable/enable tracking analytic events

### DIFF
--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/core/VGSCollect.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/core/VGSCollect.kt
@@ -688,7 +688,9 @@ class VGSCollect {
     }
 
     /**
-     * If you want to temporarily disable collecting analytics from VGS Collect SDK, you can set the value to false.
+     * If you want to disable collecting analytics from VGS Collect SDK, you can set the value to false.
+     * This helps us to understand which areas require improvements.
+     * No personal information is tracked.
      *
      * Warning: if this option is set to false, it will increase resolving time for possible incidents.
      */

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/core/VGSCollect.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/core/VGSCollect.kt
@@ -690,7 +690,7 @@ class VGSCollect {
     /**
      * If you want to temporarily disable collecting analytics from VGS Collect SDK, you can set the value to false.
      *
-     * Warning: if this option is set to false, it will increase debugging and resolving time for possible incidents.
+     * Warning: if this option is set to false, it will increase resolving time for possible incidents.
      */
     fun setAnalyticsEnabled(isEnabled: Boolean) {
         tracker.setAnalyticsEnabled(isEnabled)

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/core/VGSCollect.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/core/VGSCollect.kt
@@ -686,4 +686,13 @@ class VGSCollect {
             }
         }
     }
+
+    /**
+     * If you want to temporarily disable collecting analytics from VGS Collect SDK, you can set the value to false.
+     *
+     * Warning: if this option is set to false, it will increase debugging and resolving time for possible incidents.
+     */
+    fun setAnalyticsEnabled(isEnabled: Boolean) {
+        tracker.setAnalyticsEnabled(isEnabled)
+    }
 }

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/core/api/analityc/AnalyticTracker.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/core/api/analityc/AnalyticTracker.kt
@@ -3,5 +3,6 @@ package com.verygoodsecurity.vgscollect.core.api.analityc
 import com.verygoodsecurity.vgscollect.core.api.analityc.action.Action
 
 interface AnalyticTracker {
+    fun setAnalyticsEnabled(isEnabled: Boolean)
     fun logEvent(action: Action)
 }

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/core/api/analityc/CollectActionTracker.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/core/api/analityc/CollectActionTracker.kt
@@ -24,14 +24,22 @@ internal class CollectActionTracker(
         return@lazy ApiClient.newHttpClient(false)
     }
 
-    override fun logEvent(action: Action) {
-        val event = action.run {
-            val sender = Event(client, tnt, environment, formId)
-            sender.map = getAttributes()
-            sender
-        }
+    private var isAnalyticEnabled = true
 
-        Executors.newSingleThreadExecutor().submit(event)
+    override fun setAnalyticsEnabled(isEnabled: Boolean) {
+        isAnalyticEnabled = isEnabled
+    }
+
+    override fun logEvent(action: Action) {
+        if(isAnalyticEnabled) {
+            val event = action.run {
+                val sender = Event(client, tnt, environment, formId)
+                sender.map = getAttributes()
+                sender
+            }
+
+            Executors.newSingleThreadExecutor().submit(event)
+        }
     }
 
     private class Event(


### PR DESCRIPTION
## Feature [ANDROIDSDK-156]

## Description of changes
Was added the ability to disable analytic events inside VGS Collect SDK.

## Example
```vgsForm.setAnalyticsEnabled(false)```


[ANDROIDSDK-156]: https://verygoodsecurity.atlassian.net/browse/ANDROIDSDK-156