### PR TITLE
Fix keyboard doesn't show after reopen app

### DIFF
--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/InputFieldView.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/InputFieldView.kt
@@ -459,20 +459,14 @@ abstract class InputFieldView @JvmOverloads constructor(
      *
      * @return True if this view has focus, false otherwise.
      */
-    override fun isFocused(): Boolean {
-        return inputField.isFocused
-    }
+    override fun isFocused(): Boolean = inputField.isFocused
 
     /**
      * Find the view in the hierarchy rooted at this view that currently has focus.
      *
      * @return The view that currently has focus, or null if no focused view can be found.
      */
-    override fun findFocus(): View? {
-        return inputField.findFocus()?.run {
-            this@InputFieldView
-        }
-    }
+    override fun findFocus(): View = inputField.findFocus()
 
     /**
      * Set whether this view can receive the focus.


### PR DESCRIPTION
## Feature [ANDROIDSDK-404](https://verygoodsecurity.atlassian.net/browse/ANDROIDSDK-404)

## Description of changes
Fix `findFocus()` function return value.

### How to test
1. Checkout development branch.
2. Create activity with any InputFieldView implementation (VGSEditText etc.). Important: does not use VGSTextInputLayout.
3. Complete steps from task description. Bug should be reproduced.
4. Checkout fix/ANDROIDSDK-404.
5. Complete step 2 and 3 from this list. Bug should not be reproduced.