### PR TITLE
Implement ability to set tag for logs produced by VGSCollectLogger 

### DIFF
--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/VGSCollectLogger.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/VGSCollectLogger.kt
@@ -8,13 +8,16 @@ import com.verygoodsecurity.vgscollect.VGSCollectLogger.Level.*
  */
 object VGSCollectLogger {
 
-    private const val TAG = "VGSCollect"
+    const val DEFAULT_TAG = "VGSCollect"
 
     /** Current priority level for filtering debugging logs */
-    var logLevel: Level = if(BuildConfig.DEBUG) DEBUG else NONE
+    var logLevel: Level = DEBUG
 
     /** Allows enable and disable debug-log printing. */
-    var isEnabled = BuildConfig.DEBUG
+    var isEnabled = true
+
+    /** Current logs tag */
+    var tag: String = DEFAULT_TAG
 
     /**
      * Priority constant for the printing debug-logs.
@@ -41,15 +44,17 @@ object VGSCollectLogger {
     /**
      * Returns true if the logger print log messages.
      */
-    fun isDebugEnabled(): Boolean = logLevel.ordinal != NONE.ordinal
+    fun isDebugEnabled(): Boolean = isEnabled && (logLevel.ordinal != NONE.ordinal)
 
-    private fun printLog(level: Level, tag: String?, message: String) {
-        if(isEnabled && level.ordinal >= logLevel.ordinal) {
-            val log:String = if(tag.isNullOrEmpty()) message else "$tag: $message"
+    private fun printLog(level: Level, prefix: String?, message: String) {
+        if (isEnabled && level.ordinal >= logLevel.ordinal) {
+            val log: String = if (prefix.isNullOrEmpty()) message else "$prefix: $message"
 
             when (level) {
-                DEBUG -> Log.d(TAG, log)
-                WARN -> Log.w(TAG, log)
+                DEBUG -> Log.d(this.tag, log)
+                WARN -> Log.w(this.tag, log)
+                NONE -> {
+                }
             }
         }
     }

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/VGSCollectLogger.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/VGSCollectLogger.kt
@@ -8,7 +8,7 @@ import com.verygoodsecurity.vgscollect.VGSCollectLogger.Level.*
  */
 object VGSCollectLogger {
 
-    const val DEFAULT_TAG = "VGSCollect"
+    const val TAG = "VGSCollect"
 
     /** Current priority level for filtering debugging logs */
     var logLevel: Level = DEBUG
@@ -17,7 +17,7 @@ object VGSCollectLogger {
     var isEnabled = true
 
     /** Current logs tag */
-    var tag: String = DEFAULT_TAG
+    var tag: String = TAG
 
     /**
      * Priority constant for the printing debug-logs.


### PR DESCRIPTION
## Feature [ANDROIDSDK-403](https://verygoodsecurity.atlassian.net/browse/ANDROIDSDK-403)

## Description of changes
 - Add `tag` property to `VGSCollectLogger`.
 - Make `VGSCollectLogger.DEFAULT_TAG` public, so devs can use it for reset tag.

## Example
Set tag: `VGSCollectLogger.tag = "Test tag"`
Clear tag: `VGSCollectLogger.tag = VGSCollectLogger.DEFAULT_TAG`
