### PR TITLE
Add textCapCharacters for VGSEditText in Android SDK

### DIFF
--- a/app/src/main/res/layout/instrumented_activity_vgs_edittext_input_type.xml
+++ b/app/src/main/res/layout/instrumented_activity_vgs_edittext_input_type.xml
@@ -35,4 +35,10 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:inputType="date" />
+
+    <com.verygoodsecurity.vgscollect.widget.VGSEditText
+        android:id="@+id/vgsEditTextCapCharacters"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:inputType="textCapCharacters" />
 </LinearLayout>

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/InfoInputField.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/InfoInputField.kt
@@ -38,6 +38,7 @@ internal class InfoInputField(context: Context) : BaseInputField(context) {
             InputType.TYPE_CLASS_NUMBER,
             InputType.TYPE_CLASS_DATETIME,
             InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_VARIATION_PASSWORD -> {}
+            InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS -> {}
             InputType.TYPE_TEXT_VARIATION_PASSWORD,
             InputType.TYPE_NUMBER_VARIATION_PASSWORD,
             InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD -> {

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/widget/VGSEditText.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/widget/VGSEditText.kt
@@ -2,6 +2,7 @@ package com.verygoodsecurity.vgscollect.widget
 
 import android.content.Context
 import android.graphics.Color
+import android.text.InputType
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.Gravity
@@ -73,6 +74,14 @@ open class VGSEditText @JvmOverloads constructor(
                 recycle()
             }
         }
+    }
+
+    override fun setInputType(inputType: Int) {
+        if (inputType == InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS) {
+            super.setInputType(getInputType() or inputType)
+            return
+        }
+        super.setInputType(inputType)
     }
 
     /**

--- a/vgscollect/src/main/res/values/attrs.xml
+++ b/vgscollect/src/main/res/values/attrs.xml
@@ -121,6 +121,9 @@
              {@link android.text.InputType#TYPE_CLASS_DATETIME} |
              {@link android.text.InputType#TYPE_DATETIME_VARIATION_DATE}. -->
         <enum name="date" value="4" />
+
+        <!-- Corresponds to {@link android.text.InputType#TYPE_TEXT_FLAG_CAP_CHARACTERS}. -->
+        <enum name="textCapCharacters" value="4096" />
     </attr>
 
     <!-- Where to ellipsize text. -->


### PR DESCRIPTION
## Feature [ANDROIDSDK-413]

## Description of changes
Add possibility to set textCapCharacters in VGSEditText


[ANDROIDSDK-413]: https://verygoodsecurity.atlassian.net/browse/ANDROIDSDK-413