### PR TITLE
Fix nullable return type

### DIFF
--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/InputFieldView.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/InputFieldView.kt
@@ -477,7 +477,7 @@ abstract class InputFieldView @JvmOverloads constructor(
      *
      * @return The view that currently has focus, or null if no focused view can be found.
      */
-    override fun findFocus(): View = inputField.findFocus()
+    override fun findFocus(): View? = inputField.findFocus()
 
     /**
      * Set whether this view can receive the focus.


### PR DESCRIPTION
## Feature [ANDROIDSDK-520](https://verygoodsecurity.atlassian.net/browse/ANDROIDSDK-521)

## Description of changes
- Fix `InputFieldView.findFocus()` nullable return type.
