### PR TITLE
Add ability to force application theme in card.io flow

### DIFF
--- a/vgscollect-cardio/src/main/java/com/verygoodsecurity/api/cardio/ScanActivity.kt
+++ b/vgscollect-cardio/src/main/java/com/verygoodsecurity/api/cardio/ScanActivity.kt
@@ -8,17 +8,17 @@ import io.card.payment.CardIOActivity
 import io.card.payment.CreditCard
 import java.text.SimpleDateFormat
 import java.util.*
-import kotlin.collections.HashMap
 
-class ScanActivity: BaseTransmitActivity() {
+class ScanActivity : BaseTransmitActivity() {
 
-    private lateinit var settings:Map<String, Int>
-    private var requirePostalCode:Boolean = false
-    private var suppressConfirmation:Boolean = true
-    private var suppressManualEnter:Boolean = true
-    private var configuredScanInstructions:String? = null
-    private var configuredLocale:String? = null
-    private var configuredColor:Int? = null
+    private lateinit var settings: Map<String, Int>
+    private var requirePostalCode: Boolean = false
+    private var suppressConfirmation: Boolean = true
+    private var suppressManualEnter: Boolean = true
+    private var keepApplicationTheme: Boolean = false
+    private var configuredScanInstructions: String? = null
+    private var configuredLocale: String? = null
+    private var configuredColor: Int? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -32,14 +32,15 @@ class ScanActivity: BaseTransmitActivity() {
         intent.extras?.let {
             settings = it.getSerializable(SCAN_CONFIGURATION)?.run {
                 this as HashMap<String, Int>
-            }?:HashMap()
+            } ?: HashMap()
 
             requirePostalCode = it.getBoolean(EXTRA_REQUIRE_POSTAL_CODE, false)
             suppressConfirmation = it.getBoolean(EXTRA_SUPPRESS_CONFIRMATION, true)
             suppressManualEnter = it.getBoolean(EXTRA_SUPPRESS_MANUAL_ENTRY, true)
+            keepApplicationTheme = it.getBoolean(EXTRA_KEEP_APPLICATION_THEME, false)
             configuredScanInstructions = it.getString(EXTRA_SCAN_INSTRUCTIONS, null)
             configuredLocale = it.getString(EXTRA_LANGUAGE_OR_LOCALE, null)
-            configuredColor = if(it.containsKey(EXTRA_GUIDE_COLOR)) {
+            configuredColor = if (it.containsKey(EXTRA_GUIDE_COLOR)) {
                 it.getInt(EXTRA_GUIDE_COLOR, 0)
             } else {
                 null
@@ -54,6 +55,7 @@ class ScanActivity: BaseTransmitActivity() {
             .putExtra(CardIOActivity.EXTRA_SCAN_EXPIRY, true)
             .putExtra(CardIOActivity.EXTRA_REQUIRE_CVV, false)
             .putExtra(CardIOActivity.EXTRA_REQUIRE_POSTAL_CODE, requirePostalCode)
+            .putExtra(CardIOActivity.EXTRA_KEEP_APPLICATION_THEME, keepApplicationTheme)
 
 
         suppressManualEnter?.let {
@@ -74,18 +76,19 @@ class ScanActivity: BaseTransmitActivity() {
         }
 
 
-        startActivityForResult(scanIntent,
+        startActivityForResult(
+            scanIntent,
             CARD_IO_REQUEST_CODE
         )
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        configureInternalSettings(resultCode,data)
-        if(requestCode == CARD_IO_REQUEST_CODE) {
+        configureInternalSettings(resultCode, data)
+        if (requestCode == CARD_IO_REQUEST_CODE) {
             val scanResult: CreditCard? = data?.getParcelableExtra(CardIOActivity.EXTRA_SCAN_RESULT)
             scanResult?.run {
                 settings.forEach {
-                    when(it.value) {
+                    when (it.value) {
                         CARD_NUMBER -> mapData(it.key, scanResult.cardNumber)
                         CARD_CVC -> mapData(it.key, scanResult.cvv)
                         CARD_HOLDER -> mapData(it.key, scanResult.cardholderName)
@@ -103,7 +106,7 @@ class ScanActivity: BaseTransmitActivity() {
     private fun configureInternalSettings(resultCode: Int, data: Intent?) {
         mapData(RESULT_TYPE, SCAN)
         mapData(RESULT_NAME, NAME)
-        if(data?.extras?.containsKey(CardIOActivity.EXTRA_SCAN_RESULT) == true) {
+        if (data?.extras?.containsKey(CardIOActivity.EXTRA_SCAN_RESULT) == true) {
             mapData(RESULT_STATUS, Status.SUCCESS.raw)
         } else {
             mapData(RESULT_STATUS, Status.FAILED.raw)
@@ -111,7 +114,7 @@ class ScanActivity: BaseTransmitActivity() {
     }
 
     private fun retrieveDate(scanResult: CreditCard): Long? {
-        return if(scanResult.expiryMonth != 0 && scanResult.expiryYear != 0) {
+        return if (scanResult.expiryMonth != 0 && scanResult.expiryYear != 0) {
             val yMask = scanResult.expiryYear.toString()
                 .replace("\\d".toRegex(), "y")
             val mMask = String.format("%02d", scanResult.expiryMonth)
@@ -152,6 +155,12 @@ class ScanActivity: BaseTransmitActivity() {
         const val EXTRA_SUPPRESS_CONFIRMATION = CardIOActivity.EXTRA_SUPPRESS_CONFIRMATION
         const val EXTRA_REQUIRE_POSTAL_CODE = CardIOActivity.EXTRA_REQUIRE_POSTAL_CODE
 
+        /**
+         * Boolean extra. Optional. If this value is set to <code>true</code>, and the application has a theme,
+         * the theme for the card.io {@link android.app.Activity}s will be set to the theme of the application.
+         */
+        const val EXTRA_KEEP_APPLICATION_THEME = CardIOActivity.EXTRA_KEEP_APPLICATION_THEME
+
         const val CARD_NUMBER = 0x71
         const val CARD_CVC = 0x72
         const val CARD_HOLDER = 0x73
@@ -160,7 +169,7 @@ class ScanActivity: BaseTransmitActivity() {
         private const val CARD_IO_REQUEST_CODE = 0x7
         private const val NAME = "CardIO"
 
-        fun scan(context: Activity, code:Int, bndl:Bundle = Bundle.EMPTY) {
+        fun scan(context: Activity, code: Int, bndl: Bundle = Bundle.EMPTY) {
             val intent = Intent(context, ScanActivity::class.java)
             intent.putExtras(bndl)
             context.startActivityForResult(intent, code)


### PR DESCRIPTION
## Feature [ANDROIDSDK-625](https://verygoodsecurity.atlassian.net/browse/ANDROIDSDK-625)

## Description of changes
 - Add `EXTRA_KEEP_APPLICATION_THEME` flag.
 
## Example
```
val intent = Intent(this, ScanActivity::class.java)
intent.putExtra(ScanActivity.EXTRA_KEEP_APPLICATION_THEME, false)
startActivityForResult(intent, USER_SCAN_REQUEST_CODE)
```
