### PR TITLE
Fix `VGSTextInputLayout` start/end icons

### DIFF
--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/BaseInputField.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/BaseInputField.kt
@@ -72,7 +72,6 @@ internal abstract class BaseInputField(context: Context) : TextInputEditText(con
     protected var isListeningPermitted = true
     private var isEditorActionListenerConfigured = false
     private var isKeyListenerConfigured = false
-    protected var hasRTL = false
 
     protected abstract var fieldType: FieldType
 

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/BaseInputField.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/BaseInputField.kt
@@ -401,13 +401,13 @@ internal abstract class BaseInputField(context: Context) : TextInputEditText(con
     }
 }
 
-internal fun TextInputEditText.setCompoundDrawablesOrNull(
+internal fun TextInputEditText.setCompoundDrawablesRelativeOrNull(
     start: Drawable? = null,
     top: Drawable? = null,
     end: Drawable? = null,
     bottom: Drawable? = null
 ) {
-    this.setCompoundDrawables(start, top, end, bottom)
+    this.setCompoundDrawablesRelative(start, top, end, bottom)
 }
 
 internal val TextInputEditText.localVisibleRect: Rect

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/CVCInputField.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/CVCInputField.kt
@@ -100,7 +100,6 @@ internal class CVCInputField(context: Context) : BaseInputField(context) {
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)
         if (isRTL()) {
-            hasRTL = true
             layoutDirection = View.LAYOUT_DIRECTION_LTR
             textDirection = View.TEXT_DIRECTION_LTR
             gravity = Gravity.CENTER_VERTICAL or Gravity.RIGHT

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/CVCInputField.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/CVCInputField.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.os.Build
 import android.text.InputFilter
 import android.text.InputType
-import android.view.Gravity
 import android.view.View
 import com.verygoodsecurity.vgscollect.core.model.state.Dependency
 import com.verygoodsecurity.vgscollect.core.model.state.FieldContent
@@ -97,15 +96,6 @@ internal class CVCInputField(context: Context) : BaseInputField(context) {
         filters = arrayOf(CVCValidateFilter(), filterLength)
     }
 
-    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
-        if (isRTL()) {
-            layoutDirection = View.LAYOUT_DIRECTION_LTR
-            textDirection = View.TEXT_DIRECTION_LTR
-            gravity = Gravity.CENTER_VERTICAL or Gravity.RIGHT
-        }
-    }
-
     override fun setupAutofill() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             setAutofillHints(View.AUTOFILL_HINT_CREDIT_CARD_SECURITY_CODE)
@@ -152,13 +142,13 @@ internal class CVCInputField(context: Context) : BaseInputField(context) {
             localVisibleRect
         )
         when (previewIconGravity) {
-            START -> setCompoundDrawablesOrNull(start = icon)
-            END -> setCompoundDrawablesOrNull(end = icon)
+            START -> setCompoundDrawablesRelativeOrNull(start = icon)
+            END -> setCompoundDrawablesRelativeOrNull(end = icon)
         }
     }
 
     private fun removeIcon() {
-        setCompoundDrawablesOrNull()
+        setCompoundDrawablesRelativeOrNull()
     }
 
     enum class PreviewIconVisibility {

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/CardInputField.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/CardInputField.kt
@@ -273,14 +273,14 @@ internal class CardInputField(context: Context) : BaseInputField(context),
             PreviewIconMode.IF_DETECTED -> if (card.successfullyDetected) {
                 refreshIconPreview()
             } else {
-                setCompoundDrawables(null, null, null, null)
+                setCompoundDrawablesRelative(null, null, null, null)
             }
             PreviewIconMode.HAS_CONTENT -> if (!text.isNullOrEmpty()) {
                 refreshIconPreview()
             } else {
-                setCompoundDrawables(null, null, null, null)
+                setCompoundDrawablesRelative(null, null, null, null)
             }
-            PreviewIconMode.NEVER -> setCompoundDrawables(null, null, null, null)
+            PreviewIconMode.NEVER -> setCompoundDrawablesRelative(null, null, null, null)
         }
     }
 
@@ -312,19 +312,6 @@ internal class CardInputField(context: Context) : BaseInputField(context),
                 originalCardNumberMask
             )
             applyDividerOnMask()
-        }
-    }
-
-    override fun setCompoundDrawables(
-        left: Drawable?,
-        top: Drawable?,
-        right: Drawable?,
-        bottom: Drawable?
-    ) {
-        if (hasRTL) {
-            super.setCompoundDrawables(right, top, left, bottom)
-        } else {
-            super.setCompoundDrawables(left, top, right, bottom)
         }
     }
 

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/CardInputField.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/CardInputField.kt
@@ -8,7 +8,6 @@ import android.graphics.drawable.Drawable
 import android.text.InputType
 import android.text.method.DigitsKeyListener
 import android.view.Gravity
-import android.view.View
 import com.verygoodsecurity.vgscollect.R
 import com.verygoodsecurity.vgscollect.core.model.state.*
 import com.verygoodsecurity.vgscollect.util.extension.applyLimitOnMask
@@ -170,17 +169,6 @@ internal class CardInputField(context: Context) : BaseInputField(context),
         inputConnection?.run()
     }
 
-    @SuppressLint("RtlHardcoded")
-    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
-        if (isRTL()) {
-            hasRTL = true
-            layoutDirection = View.LAYOUT_DIRECTION_LTR
-            textDirection = View.TEXT_DIRECTION_LTR
-            gravity = Gravity.CENTER_VERTICAL or Gravity.RIGHT
-        }
-    }
-
     internal fun getOutputDivider(): Char? {
         return outputDivider.firstOrNull()
     }
@@ -298,12 +286,13 @@ internal class CardInputField(context: Context) : BaseInputField(context),
 
     @SuppressLint("RtlHardcoded")
     private fun refreshIconPreview() {
-        when (iconGravity) {
-            Gravity.LEFT -> setCompoundDrawables(lastCardIconPreview, null, null, null)
-            Gravity.START -> setCompoundDrawables(lastCardIconPreview, null, null, null)
-            Gravity.RIGHT -> setCompoundDrawables(null, null, lastCardIconPreview, null)
-            Gravity.END -> setCompoundDrawables(null, null, lastCardIconPreview, null)
-            Gravity.NO_GRAVITY -> setCompoundDrawables(null, null, null, null)
+        with(iconGravity) {
+            setCompoundDrawablesRelative(
+                if (this == Gravity.LEFT || this == Gravity.START) lastCardIconPreview else null,
+                null,
+                if (this == Gravity.RIGHT || this == Gravity.END) lastCardIconPreview else null,
+                null,
+            )
         }
     }
 

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/CardInputField.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/CardInputField.kt
@@ -273,25 +273,23 @@ internal class CardInputField(context: Context) : BaseInputField(context),
             PreviewIconMode.IF_DETECTED -> if (card.successfullyDetected) {
                 refreshIconPreview()
             } else {
-                setCompoundDrawablesRelative(null, null, null, null)
+                setCompoundDrawablesRelativeOrNull()
             }
             PreviewIconMode.HAS_CONTENT -> if (!text.isNullOrEmpty()) {
                 refreshIconPreview()
             } else {
-                setCompoundDrawablesRelative(null, null, null, null)
+                setCompoundDrawablesRelativeOrNull()
             }
-            PreviewIconMode.NEVER -> setCompoundDrawablesRelative(null, null, null, null)
+            PreviewIconMode.NEVER -> setCompoundDrawablesRelativeOrNull()
         }
     }
 
     @SuppressLint("RtlHardcoded")
     private fun refreshIconPreview() {
         with(iconGravity) {
-            setCompoundDrawablesRelative(
-                if (this == Gravity.LEFT || this == Gravity.START) lastCardIconPreview else null,
-                null,
-                if (this == Gravity.RIGHT || this == Gravity.END) lastCardIconPreview else null,
-                null,
+            setCompoundDrawablesRelativeOrNull(
+                start = if (this == Gravity.LEFT || this == Gravity.START) lastCardIconPreview else null,
+                end = if (this == Gravity.RIGHT || this == Gravity.END) lastCardIconPreview else null
             )
         }
     }

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/DateInputField.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/DateInputField.kt
@@ -75,7 +75,6 @@ internal class DateInputField(context: Context): BaseInputField(context), View.O
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)
         if(isRTL()) {
-            hasRTL = true
             layoutDirection = View.LAYOUT_DIRECTION_LTR
             textDirection = View.TEXT_DIRECTION_LTR
             gravity = Gravity.CENTER_VERTICAL or Gravity.RIGHT

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/DateInputField.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/DateInputField.kt
@@ -72,15 +72,6 @@ internal class DateInputField(context: Context): BaseInputField(context), View.O
         maxDate = minDate + DateUtils.YEAR_IN_MILLIS * 20
     }
 
-    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
-        if(isRTL()) {
-            layoutDirection = View.LAYOUT_DIRECTION_LTR
-            textDirection = View.TEXT_DIRECTION_LTR
-            gravity = Gravity.CENTER_VERTICAL or Gravity.RIGHT
-        }
-    }
-
     override fun applyFieldType() {
         val timeGapsValidator = TimeGapsValidator(datePattern, minDate, maxDate)
 

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/SSNInputField.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/SSNInputField.kt
@@ -131,15 +131,6 @@ internal class SSNInputField(context: Context) : BaseInputField(context) {
         }
     }
 
-    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
-        if (isRTL()) {
-            layoutDirection = View.LAYOUT_DIRECTION_LTR
-            textDirection = View.TEXT_DIRECTION_LTR
-            gravity = Gravity.CENTER_VERTICAL or Gravity.RIGHT
-        }
-    }
-
     internal fun getOutputDivider(): Char? {
         return outputDivider.firstOrNull()
     }

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/SSNInputField.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/SSNInputField.kt
@@ -134,7 +134,6 @@ internal class SSNInputField(context: Context) : BaseInputField(context) {
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)
         if (isRTL()) {
-            hasRTL = true
             layoutDirection = View.LAYOUT_DIRECTION_LTR
             textDirection = View.TEXT_DIRECTION_LTR
             gravity = Gravity.CENTER_VERTICAL or Gravity.RIGHT

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/material/internal/InputLayoutStateImpl.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/material/internal/InputLayoutStateImpl.kt
@@ -386,9 +386,6 @@ internal class InputLayoutStateImpl(
             this.setStartIconOnClickListener(this@InputLayoutStateImpl.startIconOnClickListener)
             setStartIconTintList(this@InputLayoutStateImpl.startIconTintList)
 
-            if(this@InputLayoutStateImpl.endIconDrawable != 0) {
-                this.setEndIconDrawable(this@InputLayoutStateImpl.endIconDrawable)
-            }
             if(isPasswordVisibilityToggleEnabled) {
                 this.endIconMode = TextInputLayout.END_ICON_PASSWORD_TOGGLE
             } else {
@@ -407,6 +404,9 @@ internal class InputLayoutStateImpl(
                 this.setCounterTextAppearance(this@InputLayoutStateImpl.counterTextAppearance)
                 this.setHelperTextTextAppearance(this@InputLayoutStateImpl.helperTextTextAppearance)
                 this.setErrorTextAppearance(this@InputLayoutStateImpl.errorTextAppearance)
+            }
+            if(this@InputLayoutStateImpl.endIconDrawable != 0) {
+                this.setEndIconDrawable(this@InputLayoutStateImpl.endIconDrawable)
             }
         }
     }


### PR DESCRIPTION
## Feature [ANDROIDSDK-503]

## Description of changes
 - Fix end icon didn't show in custom mode
 - Fix cardBrand/cvc icon didn't show when icon start added
 - Fix `VGSTextInputLayout/EditText` icons rtl/ltr support.


[ANDROIDSDK-503]: https://verygoodsecurity.atlassian.net/browse/ANDROIDSDK-503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ