### PR TITLE
Add overloaded attachFile function with activity parameter

### DIFF
--- a/app/src/main/java/com/verygoodsecurity/demoapp/activity_case/VGSCollectActivity.kt
+++ b/app/src/main/java/com/verygoodsecurity/demoapp/activity_case/VGSCollectActivity.kt
@@ -387,7 +387,7 @@ class VGSCollectActivity : AppCompatActivity(), VgsCollectResponseListener, View
 
     private fun attachFile() {
         if (vgsForm.getFileProvider().getAttachedFiles().isEmpty()) {
-            vgsForm.getFileProvider().attachFile("attachments.file")
+            vgsForm.getFileProvider().attachFile(this, "attachments.file")
         } else {
             vgsForm.getFileProvider().detachAll()
         }

--- a/app/src/main/java/com/verygoodsecurity/demoapp/fragment_case/PaymentFragment.kt
+++ b/app/src/main/java/com/verygoodsecurity/demoapp/fragment_case/PaymentFragment.kt
@@ -249,7 +249,7 @@ class PaymentFragment : Fragment(), VgsCollectResponseListener, OnFieldStateChan
 
     private fun attachFile() {
         if (vgsForm.getFileProvider().getAttachedFiles().isEmpty()) {
-            vgsForm.getFileProvider().attachFile("attachments.file")
+            vgsForm.getFileProvider().attachFile(requireActivity(),"attachments.file")
         } else {
             vgsForm.getFileProvider().detachAll()
         }

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/core/storage/content/file/TemporaryFileStorage.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/core/storage/content/file/TemporaryFileStorage.kt
@@ -31,11 +31,19 @@ internal class TemporaryFileStorage(
         encodedFileMaxSize = size.toLong()
     }
 
+    @Deprecated(
+        "Deprecated, overloaded function should be used.",
+        replaceWith = ReplaceWith("attachFile(activity, fieldName)")
+    )
     override fun attachFile(fieldName: String) {
         (context as? Activity)?.startActivityForResult(
             createFilePickerIntent(fieldName),
             REQUEST_CODE
         ) ?: errorListener?.onStorageError(VGSError.NOT_ACTIVITY_CONTEXT)
+    }
+
+    override fun attachFile(activity: Activity, fieldName: String) {
+        activity.startActivityForResult(createFilePickerIntent(fieldName), REQUEST_CODE)
     }
 
     override fun getAttachedFiles(): List<FileState> = fileInfoStore.values.toList()

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/core/storage/content/file/VGSFileProvider.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/core/storage/content/file/VGSFileProvider.kt
@@ -1,5 +1,6 @@
 package com.verygoodsecurity.vgscollect.core.storage.content.file
 
+import android.app.Activity
 import com.verygoodsecurity.vgscollect.core.model.state.FileState
 
 /**
@@ -21,14 +22,27 @@ interface VGSFileProvider {
      *
      * @param fieldName is a key under which the file for JSON will be saved before sending.
      */
-    fun attachFile(fieldName : String)
+    @Deprecated(
+        message = "Deprecated, overloaded function should be used.",
+        replaceWith = ReplaceWith("attachFile(activity, fieldName)")
+    )
+    fun attachFile(fieldName: String)
+
+    /**
+     * Mentioned below method allows to attach file to the temporary local file storage before
+     * its sending to the Server.
+     *
+     * @param activity current Activity.
+     * @param fieldName is a key under which the file for JSON will be saved before sending.
+     */
+    fun attachFile(activity: Activity, fieldName: String)
 
     /**
      * Method is used to get attached files for reviewing them before their further sending.
      *
      * @return list of [FileState]
      */
-    fun getAttachedFiles():List<FileState>
+    fun getAttachedFiles(): List<FileState>
 
     /**
      * The method is used for detaching all previously attached files.

--- a/vgscollect/src/test/java/com/verygoodsecurity/vgscollect/storage/file/FileStorageTest.kt
+++ b/vgscollect/src/test/java/com/verygoodsecurity/vgscollect/storage/file/FileStorageTest.kt
@@ -166,7 +166,7 @@ class FileStorageTest {
             this
         }
 
-        provider.attachFile(fieldName)
+        provider.attachFile(activity, fieldName)
 
         verify(c).save(fieldName)
     }


### PR DESCRIPTION
## Feature [ANDROIDSDK-735]

## Description of changes
 - Add overloaded `attachFile` function with activity parameter.
 - Mark old `attachFile` function as deprecated


[ANDROIDSDK-735]: https://verygoodsecurity.atlassian.net/browse/ANDROIDSDK-735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ