### PR TITLE
Bump compile and target SDK version to 34

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,12 +6,12 @@ plugins {
 
 android {
     namespace 'com.verygoodsecurity.demoapp'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.verygoodsecurity.demoapp"
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ include ':app', ':vgscollect', ':vgscollect-cardio', ':vgscollect-blinkcard'
 dependencyResolutionManagement {
     versionCatalogs {
         gradleLibs {
-            library('tools', 'com.android.tools.build:gradle:8.1.1')
+            library('tools', 'com.android.tools.build:gradle:8.1.2')
             library('kotlin', 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.10')
             library('maven', 'com.github.dcendents:android-maven-gradle-plugin:2.1')
             library('maven-publish', 'com.vanniktech:gradle-maven-publish-plugin:0.25.3')
@@ -16,7 +16,7 @@ dependencyResolutionManagement {
         libs {
             // Libraries
             library('androidx-appcompat', 'androidx.appcompat:appcompat:1.6.1')
-            library('androidx-core-ktx', 'androidx.core:core-ktx:1.10.1')
+            library('androidx-core-ktx', 'androidx.core:core-ktx:1.12.0')
             library('material', 'com.google.android.material:material:1.9.0')
             library('okhttp', 'com.squareup.okhttp3:okhttp:4.11.0')
             library('dokka-base', 'org.jetbrains.dokka:dokka-base:1.9.0')

--- a/vgscollect-blinkcard/build.gradle
+++ b/vgscollect-blinkcard/build.gradle
@@ -7,11 +7,11 @@ plugins {
 
 android {
     namespace 'com.verygoodsecurity.api.blinkcard'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 21
-        targetSdk 33
+        targetSdk 34
         versionCode VERSION_CODE.toInteger()
         versionName VERSION_NAME
 

--- a/vgscollect-cardio/build.gradle
+++ b/vgscollect-cardio/build.gradle
@@ -8,11 +8,11 @@ plugins {
 
 android {
     namespace 'com.verygoodsecurity.api'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode VERSION_CODE.toInteger()
         versionName VERSION_NAME
 

--- a/vgscollect/build.gradle
+++ b/vgscollect/build.gradle
@@ -10,11 +10,11 @@ plugins {
 
 android {
     namespace 'com.verygoodsecurity.vgscollect'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode VERSION_CODE.toInteger()
         versionName VERSION_NAME
 


### PR DESCRIPTION
## Feature [CSDK-744]

## Description of changes
- Bump target/compile sdk version to 34
- Bump gradle version
- Bump ktx version
- Make sure nothing is broken and fully support SDK version 34

[CSDK-744]: https://verygoodsecurity.atlassian.net/browse/CSDK-744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ