### PR TITLE
CSL3-2616: Hide day in ``RangeDateEditText`` spinner if ``datePattern`` is ``MM/yy``

### DIFF
--- a/app/src/main/java/com/verygoodsecurity/demoapp/date_range_activity/DateRangeActivity.kt
+++ b/app/src/main/java/com/verygoodsecurity/demoapp/date_range_activity/DateRangeActivity.kt
@@ -129,9 +129,9 @@ class DateRangeActivity : AppCompatActivity(), VgsCollectResponseListener, OnFie
         // Specify VGSDateRangeSeparateSerializer to send day, month and year separately in json structure
         binding.vgsTiedDateRange.setSerializer(
             VGSDateRangeSeparateSerializer(
-                "date.day",
-                "date.month",
-                "date.year"
+                null,
+                "card.expiry.month",
+                "card.expiry.year",
             )
         )
         binding.vgsTiedDateRange.setOnFieldStateChangeListener(object : OnFieldStateChangeListener {

--- a/app/src/main/res/layout/activity_date_range.xml
+++ b/app/src/main/res/layout/activity_date_range.xml
@@ -60,17 +60,14 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 app:datePattern="MM/yy"
-                app:datePickerModes="input"
+                app:datePickerModes="spinner"
                 app:fieldName="date"
                 app:formatterMode="strict"
                 app:hint="Date range"
                 app:imeOptions="actionNext"
                 app:inputType="date"
                 app:minDate="02/25"
-                app:maxDate="10/25"
-                app:outputPattern="MM-yyyy-dd'T'HH:mm:ss.SSSSSSS"
-                app:text="" />
-
+                app:maxDate="10/25" />
         </com.verygoodsecurity.vgscollect.widget.VGSTextInputLayout>
 
         <com.google.android.material.button.MaterialButton

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/core/serializers/VGSDateRangeSeparateSerializer.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/core/serializers/VGSDateRangeSeparateSerializer.kt
@@ -3,7 +3,7 @@ package com.verygoodsecurity.vgscollect.view.core.serializers
 import com.verygoodsecurity.vgscollect.VGSCollectLogger
 import com.verygoodsecurity.vgscollect.core.api.client.extension.logException
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Locale
 
 /**
  * Represents [com.verygoodsecurity.vgscollect.widget.RangeDateEditText] date split serializer.
@@ -15,7 +15,7 @@ import java.util.*
  * @param yearFieldName - this field name will be used for year in request json.
  */
 class VGSDateRangeSeparateSerializer constructor(
-    private val dayFieldName: String,
+    private val dayFieldName: String?,
     private val monthFieldName: String,
     private val yearFieldName: String
 ) : FieldDataSerializer<VGSDateRangeSeparateSerializer.Params, List<Pair<String, String>>>() {
@@ -30,11 +30,13 @@ class VGSDateRangeSeparateSerializer constructor(
                 )
                 return emptyList()
             }
-            listOf(
-                dayFieldName to getDayFormat(params.dateFormat).format(date),
-                monthFieldName to getMonthFormat(params.dateFormat).format(date),
-                yearFieldName to getYearFormat(params.dateFormat).format(date)
-            )
+            val result = mutableListOf<Pair<String, String>>()
+            dayFieldName?.let {
+                result.add(dayFieldName to getDayFormat(params.dateFormat).format(date))
+            }
+            result.add(monthFieldName to getMonthFormat(params.dateFormat).format(date))
+            result.add(yearFieldName to getYearFormat(params.dateFormat).format(date))
+            result
         } catch (e: Exception) {
             logException(e)
             emptyList()

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/DateRangeInputField.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/DateRangeInputField.kt
@@ -6,13 +6,18 @@ import com.verygoodsecurity.vgscollect.view.card.FieldType
 import com.verygoodsecurity.vgscollect.view.date.DateRangeFormat
 import com.verygoodsecurity.vgscollect.view.internal.core.DateInputField
 import java.util.Calendar
+import kotlin.properties.Delegates
 
 internal class DateRangeInputField(context: Context) : DateInputField(context) {
 
     //region - Abstract implementation
     override var fieldType: FieldType = FieldType.DATE_RANGE
     override var inclusiveRangeValidation: Boolean = true
-    override var inputDatePattern = DateRangeFormat.MMddYYYY.format
+    override var inputDatePattern: String by Delegates.observable(DateRangeFormat.MMddYYYY.format) { _, _, new ->
+        DateRangeFormat.parsePatternToDateFormat(new)?.let {
+            isDaysVisible = it != DateRangeFormat.MMyy
+        }
+    }
 
     override var datePickerMinDate: Long? = Calendar.getInstance().apply {
         set(Calendar.YEAR, this.get(Calendar.YEAR) - 100)
@@ -27,5 +32,11 @@ internal class DateRangeInputField(context: Context) : DateInputField(context) {
         set(Calendar.MONTH, 0)
         setMaximumTime()
     }.timeInMillis
+
+    override var isDaysVisible: Boolean = true
+
+    override fun validateDatePattern(pattern: String?): String {
+        return DateRangeFormat.parsePatternToDateFormat(pattern)?.format ?: inputDatePattern
+    }
     //endregion
 }

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/ExpirationDateInputField.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/ExpirationDateInputField.kt
@@ -7,6 +7,8 @@ import android.view.View
 import android.view.autofill.AutofillValue
 import com.verygoodsecurity.vgscollect.util.extension.setMaximumTime
 import com.verygoodsecurity.vgscollect.view.card.FieldType
+import com.verygoodsecurity.vgscollect.view.date.DatePickerMode
+import com.verygoodsecurity.vgscollect.view.date.validation.isInputDatePatternValid
 import com.verygoodsecurity.vgscollect.view.internal.core.DateInputField
 import java.text.ParseException
 import java.text.SimpleDateFormat
@@ -20,6 +22,15 @@ internal class ExpirationDateInputField(context: Context) : DateInputField(conte
     override var inputDatePattern: String = MM_YYYY
     override var datePickerMinDate: Long? = null
     override var datePickerMaxDate: Long? = null
+    override var isDaysVisible: Boolean = false
+
+    override fun validateDatePattern(pattern: String?): String {
+        return when {
+            pattern.isNullOrEmpty() -> MM_YYYY
+            datePickerMode == DatePickerMode.INPUT && !pattern.isInputDatePatternValid() -> MM_YYYY
+            else -> pattern
+        }
+    }
 
     override fun setupAutofill() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/core/DateInputField.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/internal/core/DateInputField.kt
@@ -44,6 +44,7 @@ internal abstract class DateInputField(context: Context) : BaseInputField(contex
     internal abstract var inclusiveRangeValidation: Boolean
     internal abstract var datePickerMinDate: Long?
     internal abstract var datePickerMaxDate: Long?
+    internal abstract var isDaysVisible: Boolean
     //endregion
 
     //region - Properties
@@ -59,18 +60,16 @@ internal abstract class DateInputField(context: Context) : BaseInputField(contex
             field = value
             updateTimeGapsValidator()
         }
-    private var timeGapsValidator: TimeGapsValidator? = null
     protected val selectedDate: Calendar = Calendar.getInstance()
+    protected var datePickerMode: DatePickerMode = DatePickerMode.INPUT
+    private var timeGapsValidator: TimeGapsValidator? = null
     private var fieldDateFormat: SimpleDateFormat? = null
     private var fieldDateOutputFormat: SimpleDateFormat? = null
     private var fieldDataSerializers: List<FieldDataSerializer<*, *>>? = null
-    private var datePickerMode: DatePickerMode = DatePickerMode.INPUT
-    protected val isDaysVisible: Boolean
-        get() {
-            return fieldType == FieldType.DATE_RANGE
-        }
     private var datePickerVisibilityChangeListener: VisibilityChangeListener? = null
     //endregion
+
+    abstract fun validateDatePattern(pattern: String?): String
 
     override fun applyFieldType() {
         updateTimeGapsValidator()
@@ -301,19 +300,7 @@ internal abstract class DateInputField(context: Context) : BaseInputField(contex
     }
 
     internal fun setDatePattern(pattern: String?) {
-        if (fieldType == FieldType.DATE_RANGE) {
-            DateRangeFormat.parsePatternToDateFormat(pattern)?.let {
-                inputDatePattern = it.format
-            }
-        } else {
-            inputDatePattern = when {
-                pattern.isNullOrEmpty() -> ExpirationDateInputField.MM_YYYY
-                datePickerMode == DatePickerMode.INPUT && pattern.isInputDatePatternValid()
-                    .not() -> ExpirationDateInputField.MM_YYYY
-                else -> pattern
-            }
-        }
-
+        inputDatePattern = validateDatePattern(pattern)
         fieldDateFormat = SimpleDateFormat(inputDatePattern, Locale.US)
         isListeningPermitted = true
         formatter?.setMask(inputDatePattern)


### PR DESCRIPTION
## Feature [CSL3-2616]

## Description of changes
- Hide day in spinner if ``datePattern`` is ``MM/yy``
- Update ``VGSDateRangeSeparateSerializer``


[CSL3-2616]: https://verygoodsecurity.atlassian.net/browse/CSL3-2616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ