### PR TITLE
DEVX-1187: Update card brands lengths

### DIFF
--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/card/CardType.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/card/CardType.kt
@@ -3,6 +3,9 @@ package com.verygoodsecurity.vgscollect.view.card
 import com.verygoodsecurity.vgscollect.R
 import com.verygoodsecurity.vgscollect.view.card.validation.payment.ChecksumAlgorithm
 
+internal const val DEFAULT_CARD_MASK_16 = "#### #### #### ####"
+internal const val DEFAULT_CARD_MASK_19 = "#### #### #### #### ###"
+
 /**
  * Standard constants of credit card brands that are supported by SDK.
  *
@@ -23,7 +26,7 @@ enum class CardType(val regex:String,
     ELO(
         "^(4011(78|79)|43(1274|8935)|45(1416|7393|763(1|2))|50(4175|6699|67[0-7][0-9]|9000)|627780|63(6297|6368)|650(03([^4])|04([0-9])|05(0|1)|4(0[5-9]|3[0-9]|8[5-9]|9[0-9])|5([0-2][0-9]|3[0-8])|9([2-6][0-9]|7[0-8])|541|700|720|901)|651652|655000|655021)",
         R.drawable.ic_elo_dark,
-        "#### #### #### ####",
+        DEFAULT_CARD_MASK_16,
         ChecksumAlgorithm.LUHN,
         arrayOf(16),
         arrayOf(3)
@@ -32,7 +35,7 @@ enum class CardType(val regex:String,
     VISA_ELECTRON(
         "^4(026|17500|405|508|844|91[37])",
         R.drawable.ic_visa_electron_dark,
-        "#### #### #### ####",
+        DEFAULT_CARD_MASK_16,
         ChecksumAlgorithm.LUHN,
         arrayOf(16),
         arrayOf(3)
@@ -41,7 +44,7 @@ enum class CardType(val regex:String,
     MAESTRO(
         "^(5018|5020|5038|6304|6390[0-9]{2}|67[0-9]{4})",
         R.drawable.ic_maestro_dark,
-        "#### #### #### ####",
+        DEFAULT_CARD_MASK_19,
         ChecksumAlgorithm.LUHN,
         (12..19).toList().toTypedArray(),
         arrayOf(3)
@@ -50,7 +53,7 @@ enum class CardType(val regex:String,
     FORBRUGSFORENINGEN(
         "^600",
         R.drawable.ic_forbrugsforeningen_dark,
-        "#### #### #### ####",
+        DEFAULT_CARD_MASK_16,
         ChecksumAlgorithm.LUHN,
         arrayOf(16),
         arrayOf(3)
@@ -59,7 +62,7 @@ enum class CardType(val regex:String,
     DANKORT(
         "^5019",
         R.drawable.ic_dankort_dark,
-        "#### #### #### ####",
+        DEFAULT_CARD_MASK_16,
         ChecksumAlgorithm.LUHN,
         arrayOf(16),
         arrayOf(3)
@@ -68,7 +71,7 @@ enum class CardType(val regex:String,
     VISA(
         "^4",
         R.drawable.ic_visa_dark,
-        "#### #### #### #### ###",
+        DEFAULT_CARD_MASK_19,
         ChecksumAlgorithm.LUHN,
         arrayOf(13, 16, 19),
         arrayOf(3)
@@ -77,7 +80,7 @@ enum class CardType(val regex:String,
     MASTERCARD(
         "^(5[1-5][0-9]{4})|^(222[1-9]|22[3-9]|2[3-6]\\d{2}|27[0-1]\\d|2720)([0-9]{2})",
         R.drawable.ic_mastercard_dark,
-        "#### #### #### ####",
+        DEFAULT_CARD_MASK_16,
         ChecksumAlgorithm.LUHN,
         arrayOf(16),
         arrayOf(3)
@@ -95,7 +98,7 @@ enum class CardType(val regex:String,
     HIPERCARD(
         "^(384100|384140|384160|606282|637095|637568|60(?!11))",
         R.drawable.ic_hipercard_dark,
-        "#### #### #### #### ###",
+        DEFAULT_CARD_MASK_19,
         ChecksumAlgorithm.LUHN,
         (14..19).toList().toTypedArray(),
         arrayOf(3)
@@ -104,24 +107,25 @@ enum class CardType(val regex:String,
     DINCLUB(
         "^3(?:[689]|(?:0[059]+))",
         R.drawable.ic_diners_dark,
-        "#### ###### ######",
+        "#### ###### #########",
         ChecksumAlgorithm.LUHN,
-        arrayOf(14, 16),
+        arrayOf(14, 16, 17, 18, 19),
         arrayOf(3)
     ),
 
     DISCOVER(
         "^(6011|65|64[4-9]|622)",
         R.drawable.ic_discover_dark,
-        "#### #### #### ####",
+        DEFAULT_CARD_MASK_19,
         ChecksumAlgorithm.LUHN,
-        arrayOf(16),
+        (16..19).toList().toTypedArray(),
         arrayOf(3)
     ),
+
     UNIONPAY(
         "^(62)",
         R.drawable.ic_union_pay_dark,
-        "#### #### #### #### ###",
+        DEFAULT_CARD_MASK_19,
         ChecksumAlgorithm.NONE,
         (16..19).toList().toTypedArray(),
         arrayOf(3)
@@ -130,16 +134,16 @@ enum class CardType(val regex:String,
     JCB(
         "^(2131|1800|35)",
         R.drawable.ic_jcb_dark,
-        "#### #### #### #### ###",
+        DEFAULT_CARD_MASK_19,
         ChecksumAlgorithm.LUHN,
-        arrayOf(15, 16),
+        (16..19).toList().toTypedArray(),
         arrayOf(3)
     ),
 
     UNKNOWN(
         "^\$a",
         R.drawable.ic_card_front_preview_light,
-        "#### #### #### #### ###",
+        DEFAULT_CARD_MASK_19,
         ChecksumAlgorithm.NONE,
         (13..19).toList().toTypedArray(),
         arrayOf(3,4)


### PR DESCRIPTION
## Feature [DEVX-1187]

## Description of changes
- Update DINERSCLUB card length;
- Update DISCOVER card length;
- Update JBC card length;


[DEVX-1187]: https://verygoodsecurity.atlassian.net/browse/DEVX-1187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ