### PR TITLE
Devx 1716/add test validate vault setup

### DIFF
--- a/vgscollect/src/test/java/com/verygoodsecurity/vgscollect/VGSCollectTest.kt
+++ b/vgscollect/src/test/java/com/verygoodsecurity/vgscollect/VGSCollectTest.kt
@@ -82,6 +82,22 @@ class VGSCollectTest {
             "eu-1"
         )
         assertEquals("live-eu-1", liveEu.environment)
+
+        val sandboxAp = VGSCollect(
+            activity,
+            "testTenant",
+            "sandbox",
+            "ap-1"
+        )
+        assertEquals("sandbox-ap-1", sandboxAp.environment)
+
+        val liveAp = VGSCollect(
+            activity,
+            "testTenant",
+            "live",
+            "ap-1"
+        )
+        assertEquals("live-ap-1", liveAp.environment)
     }
 
     @Test
@@ -124,6 +140,34 @@ class VGSCollectTest {
             "eu-1"
         )
         assertEquals("https://testTenant.live-eu-1.verygoodproxy.com", liveEuBySuffix.collectURL)
+
+        val sandboxApDirectly = VGSCollect(
+            activity,
+            "testTenant",
+            "sandbox",
+            "ap-1"
+        )
+        assertEquals("https://testTenant.sandbox-ap-1.verygoodproxy.com", sandboxApDirectly.collectURL)
+        val sandboxApBySuffix = VGSCollect(
+            activity,
+            "testTenant",
+            "sandbox-ap-1",
+        )
+        assertEquals("https://testTenant.sandbox-ap-1.verygoodproxy.com", sandboxApBySuffix.collectURL)
+
+        val liveApDirectly = VGSCollect(
+            activity,
+            "testTenant",
+            "live-ap-1",
+        )
+        assertEquals("https://testTenant.live-ap-1.verygoodproxy.com", liveApDirectly.collectURL)
+        val liveApBySuffix = VGSCollect(
+            activity,
+            "testTenant",
+            "live",
+            "ap-1"
+        )
+        assertEquals("https://testTenant.live-ap-1.verygoodproxy.com", liveApBySuffix.collectURL)
     }
 
     @Test


### PR DESCRIPTION
## Feature [DEVX-1716]

## Description of changes
Introduce a test that validates vault setup behavior across different region configurations (e.g., EU-1, AP-1) to catch environment-specific issues.


[DEVX-1716]: https://verygoodsecurity.atlassian.net/browse/DEVX-1716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ