### PR TITLE
Collect][Android] Improve expiration date strict formatter

### DIFF
--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/card/formatter/date/StrictExpirationDateFormatter.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/view/card/formatter/date/StrictExpirationDateFormatter.kt
@@ -7,8 +7,8 @@ internal class StrictExpirationDateFormatter(
 ) : StrictDateFormatter(source) {
 
     companion object {
-        private const val YEAR_FULL_REGEX = "^([2]|2[0]|20[234]|20[2][123456789]|20[34][0123456789])\$"
-        private const val YEAR_REGEX = "^([234]|2[123456789]|[34]\\d)\$"
+        private const val YEAR_FULL_REGEX = "^[2-9](\\d{0,1}|(0[2-9]|(?!0)\\d{2})\\d?)$"
+        private const val YEAR_REGEX = "^([2-9]|[1-9]\\d)$"
     }
 
     override val yearLongRegex: String

--- a/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/widget/ExpirationDateEditText.kt
+++ b/vgscollect/src/main/java/com/verygoodsecurity/vgscollect/widget/ExpirationDateEditText.kt
@@ -1,11 +1,11 @@
 package com.verygoodsecurity.vgscollect.widget
 
 import android.content.Context
-import android.text.format.DateUtils
 import android.util.AttributeSet
 import com.verygoodsecurity.vgscollect.view.card.FieldType
 import com.verygoodsecurity.vgscollect.widget.core.DateEditText
 import com.verygoodsecurity.vgscollect.widget.core.VisibilityChangeListener
+import java.util.concurrent.TimeUnit
 
 /**
  * A user interface element for inputting a card's expiration date.
@@ -19,7 +19,9 @@ class ExpirationDateEditText @JvmOverloads constructor(
     init {
         val minDate = System.currentTimeMillis()
         setMinDate(minDate)
-        setMaxDate(minDate + DateUtils.YEAR_IN_MILLIS * 20)
+        val daysInTwentyYears = 365L * 20
+        val twentyYearsInMillis = TimeUnit.DAYS.toMillis(daysInTwentyYears)
+        setMaxDate(minDate + twentyYearsInMillis)
     }
 
     /**

--- a/vgscollect/src/test/java/com/verygoodsecurity/vgscollect/card/formatter/ExpirationDateFormatterTest.kt
+++ b/vgscollect/src/test/java/com/verygoodsecurity/vgscollect/card/formatter/ExpirationDateFormatterTest.kt
@@ -7,7 +7,9 @@ import com.verygoodsecurity.vgscollect.view.card.formatter.date.StrictExpiration
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito.*
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
 
 class ExpirationDateFormatterTest {
 
@@ -88,7 +90,7 @@ class ExpirationDateFormatterTest {
 
         textWatcher.onTextChanged("20", 0,0,19)
         textWatcher.afterTextChanged(editable)
-        verify(editable, times(2)).replace(0, 0, "2")
+        verify(editable).replace(0, 0, "2")
 
         textWatcher.onTextChanged("26", 0,0,19)
         textWatcher.afterTextChanged(editable)
@@ -117,6 +119,11 @@ class ExpirationDateFormatterTest {
         textWatcher.onTextChanged("26/10", 0,0,19)
         textWatcher.afterTextChanged(editable)
         verify(editable).replace(0, 0, "26/10")
+
+        textWatcher.beforeTextChanged("", 0, 5, 6)
+        textWatcher.onTextChanged("50/10", 0,0,19)
+        textWatcher.afterTextChanged(editable)
+        verify(editable).replace(0, 0, "50/10")
     }
 
     @Test
@@ -233,11 +240,11 @@ class ExpirationDateFormatterTest {
 
         textWatcher.onTextChanged("12/3", 0,0,19)
         textWatcher.afterTextChanged(editable)
-        verify(editable, times(2)).replace(0, 0, "12/")
+        verify(editable).replace(0, 0, "12/")
 
         textWatcher.onTextChanged("12/2020", 0,0,19)
         textWatcher.afterTextChanged(editable)
-        verify(editable, times(3)).replace(0, 0, "12/")
+        verify(editable).replace(0, 0, "12/")
 
         textWatcher.onTextChanged("12/2039", 0,0,19)
         textWatcher.afterTextChanged(editable)
@@ -246,7 +253,7 @@ class ExpirationDateFormatterTest {
         textWatcher.beforeTextChanged("12/2039", 5, 1, 0)
         textWatcher.onTextChanged("12/209", 5, 1, 0)
         textWatcher.afterTextChanged(editable)
-        verify(editable, times(4)).replace(0, 0, "12/")
+        verify(editable).replace(0, 0, "12/")
 
         textWatcher.beforeTextChanged("10/2034", 0, 1, 0)
         textWatcher.onTextChanged("0/2034", 0, 1, 0)
@@ -267,6 +274,11 @@ class ExpirationDateFormatterTest {
         textWatcher.onTextChanged("08/2029", 6, 0, 1)
         textWatcher.afterTextChanged(editable)
         verify(editable).replace(0, 0, "08/2029")
+
+        textWatcher.beforeTextChanged("08/212", 6, 0, 1)
+        textWatcher.onTextChanged("08/2129", 6, 0, 1)
+        textWatcher.afterTextChanged(editable)
+        verify(editable).replace(0, 0, "08/2129")
     }
 
     @Test

--- a/vgscollect/src/test/java/com/verygoodsecurity/vgscollect/card/formatter/date/StrictExpirationDateFormatterTest.kt
+++ b/vgscollect/src/test/java/com/verygoodsecurity/vgscollect/card/formatter/date/StrictExpirationDateFormatterTest.kt
@@ -19,7 +19,7 @@ class StrictExpirationDateFormatterTest {
 
         private const val TEST_NEGATIVE_VALUE_1 = "12-1990"
         private const val TEST_NEGATIVE_VALUE_2 = "13-1390"
-        private const val TEST_NEGATIVE_VALUE_3 = "07-2054"
+        private const val TEST_NEGATIVE_VALUE_3 = "07-2019"
     }
 
     private lateinit var formatter: Formatter


### PR DESCRIPTION
## Feature [[DEVX-1300](https://verygoodsecurity.atlassian.net/browse/DEVX-1300)]

## Description of changes
Currently StrictDateFormatter uses a fixed regex for year validation, which will fail to execute in the future, as it’s hardcoded to 49 year max. We need to improve it and make this validation check dynamic and depend on the max date value.

[DEVX-1300]: https://verygoodsecurity.atlassian.net/browse/DEVX-1300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ